### PR TITLE
Fixes for behaviour of search.

### DIFF
--- a/lib/sequencescape-api/connection_factory/actions.rb
+++ b/lib/sequencescape-api/connection_factory/actions.rb
@@ -95,7 +95,11 @@ module Sequencescape::Api::ConnectionFactory::Actions
   private :perform
 
   def jsonify(body, options)
-    body.nil? ? {} : body.as_json(options.merge(:root => true))
+    case
+    when body.nil?        then {}
+    when body.is_a?(Hash) then body
+    else                       body.as_json(options.merge(:root => true))
+    end
   end
   private :jsonify
 

--- a/lib/sequencescape/search.rb
+++ b/lib/sequencescape/search.rb
@@ -49,6 +49,8 @@ class Sequencescape::Search < ::Sequencescape::Api::Resource
     }, __FILE__, line)
   end
 
+  attribute_reader :name
+
   search_action(:first)
   search_action(:last)
 


### PR DESCRIPTION
Firstly all searches have a name, which appears to be missing!

Secondly the parameters passed to a search are already a hash so they do
not need to be converted to JSON.  Doing this seems to solve the search
errors I'm seeing on my laptop.
