### PR TITLE
Fix issue with write-only or read-only attributes.

### DIFF
--- a/lib/sequencescape-api/resource/attributes.rb
+++ b/lib/sequencescape-api/resource/attributes.rb
@@ -20,7 +20,7 @@ module Sequencescape::Api::Resource::Attributes
     end
   end
 
-  def attribute_reader(*names)
+  def generate_attribute_reader(*names)
     options    = names.extract_options!
     conversion = options[:conversion].blank? ? nil : "try(#{options[:conversion].to_sym.inspect})"
 
@@ -41,9 +41,9 @@ module Sequencescape::Api::Resource::Attributes
     end
     extend_attribute_methods(names)
   end
-  private :attribute_reader
+  private :generate_attribute_reader
 
-  def attribute_writer(*names)
+  def generate_attribute_writer(*names)
     options = names.extract_options!
 
     names.each do |name|
@@ -59,11 +59,23 @@ module Sequencescape::Api::Resource::Attributes
     end
     extend_attribute_methods(names)
   end
+  private :generate_attribute_writer
+
+  def attribute_reader(*names)
+    attribute_accessor(*names)
+    class_eval { names.map { |m| private :"#{m}=" } }
+  end
+  private :attribute_reader
+
+  def attribute_writer(*names)
+    attribute_accessor(*names)
+    class_eval { names.map(&method(:private)) }
+  end
   private :attribute_writer
 
   def attribute_accessor(*names)
-    attribute_reader(*names)
-    attribute_writer(*names)
+    generate_attribute_reader(*names)
+    generate_attribute_writer(*names)
   end
   private :attribute_accessor
 

--- a/lib/sequencescape-api/resource/json.rb
+++ b/lib/sequencescape-api/resource/json.rb
@@ -59,11 +59,17 @@ module Sequencescape::Api::Resource::Json
   end
 
   def attributes_for_json(options)
-    # TODO: created_at, updated_at need to be hidden
+    attributes_to_send_to_server(options).tap do |changed_attributes|
+      [ 'created_at', 'updated_at' ].map(&changed_attributes.method(:delete))
+    end
+  end
+  private :attributes_for_json
+
+  def attributes_to_send_to_server(options)
     return attributes if options[:force] or (options[:action] == :create)
     Hash[changes.keys.map { |k| [ k.to_s, send(k) ] }]
   end
-  private :attributes_for_json
+  private :attributes_to_send_to_server
 
   def associations_for_json(options)
     Hash[

--- a/lib/sequencescape-api/resource/modifications.rb
+++ b/lib/sequencescape-api/resource/modifications.rb
@@ -50,7 +50,7 @@ module Sequencescape::Api::Resource::Modifications
   end
 
   def modify!(options)
-    raise Sequencescape::Api::Error, "No actions exist" if option[:url].nil? and actions.nil?
+    raise Sequencescape::Api::Error, "No actions exist" if options[:url].nil? and actions.nil?
 
     action    = options[:action]
     http_verb = options[:http_verb] || options[:action]
@@ -84,7 +84,6 @@ module Sequencescape::Api::Resource::Modifications
     case
     when name.to_s == 'actions'                     then update_actions(value)
     when name.to_s == 'uuid'                        then @uuid = (value || @uuid)
-    when is_attribute?(name)                        then attributes[name.to_s] = value # Handles read-only attributes
     when respond_to?(:"#{name}=", :include_private) then send(:"#{name}=", value)
     else # TODO: Maybe we need debug logging in here at some point!
     end

--- a/spec/sequencescape-api/contracts/model-c-instance-updated.txt
+++ b/spec/sequencescape-api/contracts/model-c-instance-updated.txt
@@ -10,7 +10,8 @@ Content-Type: application/json
 
     "uuid": "UUID",
     "changes_during_update": "changed",
-    "remains_same_during_update": "stays the same"
+    "remains_same_during_update": "stays the same",
+    "write_only": "has been set"
   }
 }
 

--- a/spec/sequencescape-api/contracts/update-model-c.txt
+++ b/spec/sequencescape-api/contracts/update-model-c.txt
@@ -5,6 +5,7 @@ Cookie: WTSISignOn=single-sign-on-cookie
 
 {
   "model_c": {
-    "changes_during_update": "sent from client"
+    "changes_during_update": "sent from client",
+    "write_only": "has been set"
   }
 }

--- a/spec/sequencescape-api/modifications_spec.rb
+++ b/spec/sequencescape-api/modifications_spec.rb
@@ -95,7 +95,11 @@ describe 'Updating a resource' do
     stub_request_from('update-model-c') { response('model-c-instance-updated') }
 
     before(:each) do
-      subject.update_attributes!(:changes_during_update => 'sent from client', :remains_same_during_update => 'from JSON')
+      subject.update_attributes!(
+        :changes_during_update => 'sent from client',
+        :remains_same_during_update => 'from JSON',
+        :write_only => 'has been set'
+      )
     end
 
     it_behaves_like 'it is updating a resource'
@@ -107,6 +111,7 @@ describe 'Updating a resource' do
     before(:each) do
       subject.changes_during_update      = 'sent from client'
       subject.remains_same_during_update = 'from JSON'
+      subject.write_only                 = 'has been set'
       subject.save!
     end
 

--- a/spec/support/namespaces.rb
+++ b/spec/support/namespaces.rb
@@ -23,6 +23,9 @@ module Unauthorised
     end
 
     attribute_accessor :changes_during_update, :remains_same_during_update
+
+    attribute_reader :read_only
+    attribute_writer :write_only
   end
 
   class Page < Sequencescape::Api::Resource


### PR DESCRIPTION
Unfortunately the read-only fix broke the changes code and the
write-only attributes were completely broken.  ActiveModel requires a
reader method to read the changes, and we need to be able to signal that
a value has changed.  So this code always generates both a reader and a
writer but hides the ones that are not needed.
