### PR TITLE
[fixes 22085363] Do not inline the wells in the plate JSON.

### DIFF
--- a/lib/sequencescape/plate.rb
+++ b/lib/sequencescape/plate.rb
@@ -6,7 +6,7 @@ class Sequencescape::Plate < ::Sequencescape::Asset
   include Sequencescape::Behaviour::Barcoded
   include Sequencescape::Behaviour::StateDriven
 
-  has_many :wells, :disposition => :inline
+  has_many :wells
   belongs_to :plate_purpose
   composed_of :stock_plate, :class_name => 'Plate'
 


### PR DESCRIPTION
This is so that the performance of the pulldown inbox is better at the
sacrifice of a small drop for individual plates.
