### PR TITLE
Support attribute_groups in association proxies

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -5,11 +5,11 @@
 
 # First we specify our desired <ruby>[@<gemset>], the @gemset name is optional,
 # Only full ruby name is supported here, for short names use:
-#     echo "rvm use 1.9.2" > .rvmrc
-environment_id="ruby-1.9.2-p318@sequencescape-api"
+#     echo "rvm use 1.9.3" > .rvmrc
+environment_id="ruby-1.9.3-p194@sequencescape-api"
 
 # Uncomment the following lines if you want to verify rvm version per project
-# rvmrc_rvm_version="1.10.3" # 1.10.1 seams as a safe start
+# rvmrc_rvm_version="1.15.3 (master)" # 1.10.1 seams as a safe start
 # eval "$(echo ${rvm_version}.${rvmrc_rvm_version} | awk -F. '{print "[[ "$1*65536+$2*256+$3" -ge "$4*65536+$5*256+$6" ]]"}' )" || {
 #   echo "This .rvmrc file requires at least RVM ${rvmrc_rvm_version}, aborting loading."
 #   return 1
@@ -40,7 +40,7 @@ fi
 # If you use bundler, this might be useful to you:
 # if [[ -s Gemfile ]] && {
 #   ! builtin command -v bundle >/dev/null ||
-#   builtin command -v bundle | grep $rvm_path/bin/bundle >/dev/null
+#   builtin command -v bundle | GREP_OPTIONS= \grep $rvm_path/bin/bundle >/dev/null
 # }
 # then
 #   printf "%b" "The rubygem 'bundler' is not installed. Installing it now.\n"
@@ -48,5 +48,5 @@ fi
 # fi
 # if [[ -s Gemfile ]] && builtin command -v bundle >/dev/null
 # then
-#   bundle install | grep -vE '^Using|Your bundle is complete'
+#   bundle install | GREP_OPTIONS= \grep -vE '^Using|Your bundle is complete'
 # fi

--- a/lib/sequencescape-api/resource/attribute_groups.rb
+++ b/lib/sequencescape-api/resource/attribute_groups.rb
@@ -19,6 +19,10 @@ module Sequencescape::Api::Resource::Groups
       super
       attribute_groups.values.map(&:clear_changed_attributes)
     end
+
+    def eager_loaded_attribute?(name)
+      super or attribute_groups.key?(name.to_sym)
+    end
   end
 
   module Json

--- a/sequencescape-api.gemspec
+++ b/sequencescape-api.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '~> 3.0.0')
   s.add_dependency('activemodel', '~> 3.0.0')
   s.add_dependency('i18n')
-  s.add_dependency('yajl-ruby', '~> 0.8.3')
+  s.add_dependency('yajl-ruby', '~> 1.1.0')
 
-  s.add_development_dependency('rspec', '~> 2.3.0')
+  s.add_development_dependency('rspec', '~> 2.11.0')
   s.add_development_dependency('webmock')
 end

--- a/spec/sequencescape-api/associations_spec.rb
+++ b/spec/sequencescape-api/associations_spec.rb
@@ -4,19 +4,6 @@ describe 'Various associations' do
   is_working_as_an_unauthorised_client
 
   context 'has_many' do
-    shared_examples_for 'a paged result' do
-      it 'physically contains 3 items' do
-        subject.map(&:inspect).size.should == 3
-      end
-
-      it 'can be walked in pages' do
-        check = double('check that page gets called at least once')
-        check.should_receive(:called).at_least(1).at_most(3)
-
-        subject.each_page(&check.method(:called))
-      end
-    end
-
     context 'with size included in the JSON' do
       stub_request_from('retrieve-model') { response('model-a-instance') }
 
@@ -85,6 +72,10 @@ describe 'Various associations' do
       subject { resource.model_with_early_data }
 
       its(:name) { should == 'early data from JSON' }
+
+      it 'has grouped data' do
+        subject.group.data.should == 'early group data from JSON'
+      end
 
       context do
         stub_request_and_response('belongs-to-association')

--- a/spec/sequencescape-api/contracts/model-b-instance.txt
+++ b/spec/sequencescape-api/contracts/model-b-instance.txt
@@ -28,7 +28,10 @@ Content-Type: application/json
       "actions": {
         "read": "http://localhost:3000/BELONGS_TO_UUID"
       },
-      "name": "early data from JSON"
+      "name": "early data from JSON",
+      "group": {
+        "data": "early group data from JSON"
+      }
     }
   }
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'sequencescape'
 $:.push(File.expand_path(File.join(File.dirname(__FILE__), 'support')))
 require 'contract_helper'
 require 'namespaces'
+require 'shared_examples'
 
 # Ensure that RSpec mocking is used
 RSpec.configure do |config|

--- a/spec/support/namespaces.rb
+++ b/spec/support/namespaces.rb
@@ -5,6 +5,9 @@ module Unauthorised
     has_many :model_bs
 
     attribute_accessor :name, :data
+    attribute_group :group do
+      attribute_accessor :data
+    end
   end
 
   class ModelB < Sequencescape::Api::Resource

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,12 @@
+shared_examples_for 'a paged result' do
+  it 'physically contains 3 items' do
+    subject.map(&:inspect).size.should == 3
+  end
+
+  it 'can be walked in pages' do
+    check = double('check that page gets called at least once')
+    check.should_receive(:called).at_least(1).at_most(3)
+
+    subject.each_page(&check.method(:called))
+  end
+end


### PR DESCRIPTION
Upgrading supporting code to work under Lion as YAJL & RSpec went nuts.
