### PR TITLE
[#38342385] Use the renamed Plate attributes

### DIFF
--- a/lib/sequencescape-api/resource/attributes.rb
+++ b/lib/sequencescape-api/resource/attributes.rb
@@ -26,7 +26,7 @@ module Sequencescape::Api::Resource::Attributes
     end
 
     def size
-      dimension["row_number"]*dimension["column_number"]
+      dimension["number_of_rows"]*dimension["number_of_columns"]
     end
   end
 

--- a/spec/sequencescape-api/contracts/model-d-instance.txt
+++ b/spec/sequencescape-api/contracts/model-d-instance.txt
@@ -7,7 +7,7 @@ Content-Type: application/json
       "read": "http://localhost:3000/UUID",
       "update": "http://localhost:3000/UUID"
      },
-     "dimension": {"row_number":8, "column_number":12},
+     "dimension": {"number_of_rows":8, "number_of_columns":12},
      "model_es": {"A1":[{}, {}],"A2":[{}],"A3":[{}]}
   }
 }


### PR DESCRIPTION
The row/column_number attributes of Plate resource
has been renamed to number_of_rows/columns 
in the lims-core module. 
We should use the new attributes, now.
