### PR TITLE
[#39472441] Refactored SizeCalculator for plate

### DIFF
--- a/lib/sequencescape-api/resource/attributes.rb
+++ b/lib/sequencescape-api/resource/attributes.rb
@@ -22,11 +22,11 @@ module Sequencescape::Api::Resource::Attributes
 
   module SizeCalculator
     def self.included(base)
-      base.class_eval { attribute_accessor :dimension }
+      base.class_eval { attribute_accessor :number_of_rows, :number_of_columns}
     end
 
     def size
-      dimension["number_of_rows"]*dimension["number_of_columns"]
+      number_of_rows*number_of_columns
     end
   end
 

--- a/spec/sequencescape-api/contracts/model-d-instance.txt
+++ b/spec/sequencescape-api/contracts/model-d-instance.txt
@@ -7,7 +7,8 @@ Content-Type: application/json
       "read": "http://localhost:3000/UUID",
       "update": "http://localhost:3000/UUID"
      },
-     "dimension": {"number_of_rows":8, "number_of_columns":12},
+     "number_of_rows":8,
+     "number_of_columns":12,
      "model_es": {"A1":[{}, {}],"A2":[{}],"A3":[{}]}
   }
 }


### PR DESCRIPTION
Removed dimension property from plate JSON. We 
assumed faulty, that the properties helping 
calculate the size of the wells is the children of
the 'dimension' property.
