### PR TITLE
Add transfer request collections

### DIFF
--- a/lib/sequencescape-api/associations/belongs_to.rb
+++ b/lib/sequencescape-api/associations/belongs_to.rb
@@ -101,6 +101,12 @@ module Sequencescape::Api::Associations::BelongsTo
     def uuid_only?
       @object.__send__(:uuid_only?)
     end
+
+    delegate :hash, to: :uuid
+
+    def eql?(other)
+      uuid == other.uuid
+    end
   end
 
   def belongs_to(association, options = {}, &block)

--- a/lib/sequencescape-api/resource/attribute_groups.rb
+++ b/lib/sequencescape-api/resource/attribute_groups.rb
@@ -29,7 +29,11 @@ module Sequencescape::Api::Resource::Groups
     def as_json_for_update(options)
       super.tap do |json|
         begin
-          json.fetch(json_root).merge!(attribute_group_json(options))
+          if options[:root]
+            json.fetch(json_root).merge!(attribute_group_json(options))
+          else
+            json.merge!(attribute_group_json(options))
+          end
         rescue KeyError => e
           # If we get a key error, append the json to out exception to assist diagnosing issues
           e.message << " in #{json.to_json}"

--- a/lib/sequencescape-api/resource/json.rb
+++ b/lib/sequencescape-api/resource/json.rb
@@ -109,7 +109,7 @@ module Sequencescape::Api::Resource::Json
     ]
   end
   private :associations_for_json
-  
+
   def must_output_full_json?(options, target = self)
     options[:force] or (options[:action] == :create) or target.changed?
   end

--- a/lib/sequencescape.rb
+++ b/lib/sequencescape.rb
@@ -40,6 +40,9 @@ require 'sequencescape/search'
 require 'sequencescape/work_completion'
 require 'sequencescape/custom_metadatum_collection'
 
+require 'sequencescape/transfer_request_collection'
+require 'sequencescape/transfer_request'
+
 # Pulldown API support
 require 'sequencescape/plate_creation'
 require 'sequencescape/pooled_plate_creation'

--- a/lib/sequencescape/plate.rb
+++ b/lib/sequencescape/plate.rb
@@ -17,6 +17,7 @@ class Sequencescape::Plate < ::Sequencescape::Asset
 
   has_many :wells
   has_many :submission_pools
+  has_many :transfer_request_collections
 
   belongs_to :plate_purpose
   belongs_to :custom_metadatum_collection

--- a/lib/sequencescape/transfer_request.rb
+++ b/lib/sequencescape/transfer_request.rb
@@ -1,0 +1,10 @@
+require 'sequencescape-api/resource'
+
+class Sequencescape::TransferRequest < ::Sequencescape::Api::Resource
+
+  belongs_to :source_asset, :class_name => 'Asset'
+  belongs_to :target_asset, :class_name => 'Asset'
+
+  attribute_accessor :type, :state
+
+end

--- a/lib/sequencescape/transfer_request_collection.rb
+++ b/lib/sequencescape/transfer_request_collection.rb
@@ -1,0 +1,8 @@
+require 'sequencescape-api/resource'
+
+class Sequencescape::TransferRequestCollection < ::Sequencescape::Api::Resource
+  belongs_to :user
+  # attribute_accessor :transfer_requests
+  has_many :transfer_requests, disposition: :inline
+  has_many :target_tubes, disposition: :inline, class_name: 'Tube'
+end

--- a/spec/sequencescape-api/contracts/create-model-c-has-many-inline-nested.txt
+++ b/spec/sequencescape-api/contracts/create-model-c-has-many-inline-nested.txt
@@ -1,0 +1,10 @@
+POST /model_c/create HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Cookie: WTSISignOn=single-sign-on-cookie
+
+{
+  "model_c": {
+    "model_bs": [{"test_attribute":"test_value"}]
+  }
+}

--- a/spec/sequencescape-api/modifications_spec.rb
+++ b/spec/sequencescape-api/modifications_spec.rb
@@ -70,6 +70,16 @@ describe 'Creating a resource' do
       it 'raises if not given an enumerable'
     end
 
+    context 'has_many disposition: :inline nested' do
+      stub_request_from('create-model-c-has-many-inline-nested') { response('model-c-instance-created') }
+
+      it 'takes an array of objects and converts them to UUID'
+      it 'assumes an array of strings are UUIDs' do
+        target.create!(:model_bs => [{ "test_attribute" => "test_value" }])
+      end
+      it 'raises if not given an enumerable'
+    end
+
     context 'has_many' do
       stub_request_from('create-model-c-has-many') { response('model-c-instance-created') }
 

--- a/spec/support/namespaces.rb
+++ b/spec/support/namespaces.rb
@@ -27,6 +27,7 @@ module Unauthorised
     belongs_to :model_by_simple_name, :class_name => 'ModelA'
     belongs_to :model_by_full_name, :class_name => 'Nested::Model'
     belongs_to :model_with_early_data, :class_name => 'ModelA'
+    attribute_accessor :test_attribute
   end
 
   class ModelC < Sequencescape::Api::Resource


### PR DESCRIPTION
45a33dd - Simple commit, adds transfer request collections and transfer requests. Transfer requests have been added as a separate model, rather then just using the existint request API to ensure they can be kept lightweight and simple. Existing requests rended a substantial ammount of information, including full representations of the target assets. This was particularly an issue here, as potentially one tube would be rendered in full 96 times. Resulting in 96*96 copies of the sample metadata.

d0f598 - Add support for nested_attributes_for to this side of the API. The support was almost there, but a bug assumed that the root json would be be present, even when configured otherwise. This fixes that bug, and ensures there is test coverage.