### PR TITLE
Add custom tube naming

### DIFF
--- a/lib/sequencescape/specific_tube_creation.rb
+++ b/lib/sequencescape/specific_tube_creation.rb
@@ -3,6 +3,6 @@ require 'sequencescape-api/resource'
 class Sequencescape::SpecificTubeCreation < ::Sequencescape::Api::Resource
   belongs_to :user
   belongs_to :parent, :class_name => 'Plate'
-  attribute_writer :child_purposes #, :class_name => 'TubePurpose'
+  attribute_writer :child_purposes, :tube_attributes
   has_many :children, :class_name => 'Tube'
 end


### PR DESCRIPTION
Rather than explicitly adding just a name attribute, you can now pass in the attributes of the tubes which will get created. This is an array of hashes. (One hash for each tube)

Note: We should probably re-visit the passing in the desired purposes as a separate array once we've got rid of the old high throughput lims. A single purpose better matches the behaviour elsewhere, and we don't really need the multi-purpose behaviour. (And if we did, we could handle it in the client). The other option of course would be to avoid needing purpose entirely, and to extract it from the tube options. 