### PR TITLE
DPL-033 SpecificTubeCreation multiple parents

### DIFF
--- a/lib/sequencescape/specific_tube_creation.rb
+++ b/lib/sequencescape/specific_tube_creation.rb
@@ -3,6 +3,7 @@ require 'sequencescape-api/resource'
 class Sequencescape::SpecificTubeCreation < ::Sequencescape::Api::Resource
   belongs_to :user
   belongs_to :parent, class_name: 'Plate'
+  has_many :parents, class_name: 'Asset'
   attribute_writer :child_purposes, :tube_attributes
   has_many :children, class_name: 'Tube'
 end


### PR DESCRIPTION
Allow SpecificTubeCreation to have multiple parents, to support sending through a SpikedBufferTube as a parent as well as a plate. Leave the old association for backwards compatibility:
