### PR TITLE
DPL-067-2

### DIFF
--- a/lib/sequencescape-api/version.rb
+++ b/lib/sequencescape-api/version.rb
@@ -1,5 +1,5 @@
 module Sequencescape
   class Api
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.7.0'.freeze
   end
 end

--- a/lib/sequencescape/transfer_request.rb
+++ b/lib/sequencescape/transfer_request.rb
@@ -6,5 +6,5 @@ class Sequencescape::TransferRequest < ::Sequencescape::Api::Resource
   belongs_to :submission, class_name: 'Submission'
   belongs_to :outer_request, class_name: 'Request'
 
-  attribute_accessor :type, :state, :submission_id, :volume, :merge_equivalent_aliquots
+  attribute_accessor :type, :state, :submission_id, :volume, :merge_equivalent_aliquots, :tag_position
 end

--- a/lib/sequencescape/transfer_request.rb
+++ b/lib/sequencescape/transfer_request.rb
@@ -6,5 +6,5 @@ class Sequencescape::TransferRequest < ::Sequencescape::Api::Resource
   belongs_to :submission, class_name: 'Submission'
   belongs_to :outer_request, class_name: 'Request'
 
-  attribute_accessor :type, :state, :submission_id, :volume, :merge_equivalent_aliquots, :tag_position
+  attribute_accessor :type, :state, :submission_id, :volume, :merge_equivalent_aliquots, :tag_depth
 end


### PR DESCRIPTION
When ready to deploy to UAT
Run `rake release` in gem console

Version 0.7.0 -> added aliquot_attributes param (released Sept 20th)
Version 0.7.1 -> reverting this (to be released)

Then also pull version 0.7.0 from https://rubygems.org/gems/sequencescape-client-api/versions/ 